### PR TITLE
Fix health display

### DIFF
--- a/gamemodes/zombiesurvival/gamemode/vgui/zshealtharea.lua
+++ b/gamemodes/zombiesurvival/gamemode/vgui/zshealtharea.lua
@@ -10,7 +10,7 @@ local function ContentsPaint(self)
 		colHealth.r = (1 - healthperc) * 180
 		colHealth.g = healthperc * 180
 
-		draw.SimpleTextBlurry(health, "ZSHUDFont", 8, self:GetTall() - 8, colHealth, TEXT_ALIGN_LEFT, TEXT_ALIGN_TOP)
+		draw.SimpleTextBlurry(health, "ZSHUDFont", 8, self:GetTall() - 8, colHealth, TEXT_ALIGN_LEFT, TEXT_ALIGN_BOTTOM)
 	end
 end
 


### PR DESCRIPTION
TEXT_ALIGN_TOP / TEXT_ALIGN_BOTTOM behavior was reversed. A gmod update finally, silently, fixed them.

note, I fixed all cases of this in the upcoming update but this is here as a temp fix since it's a big deal.
